### PR TITLE
Language file support

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+use std::str::Split;
+use std::ops::FnMut;
+use std::collections::hash_map::Iter;
+
+#[derive(Debug)]
+pub struct Directory<V> {
+	root: Node<V>
+}
+
+impl<V> Directory<V> {
+	pub fn new() -> Self {
+		Directory { root: Node::dummy() }
+	}
+	
+	pub fn get(&self, key: &str) -> Option<&V> {
+		let mut node = &self.root;
+		
+		for part in key.split(".") {
+			if let Some(deeper) = node.deeper(part) {
+				node = deeper;
+			} else {
+				return None;
+			}
+		}
+		
+		node.get()
+	}
+	
+	pub fn insert(&mut self, key: &str, value: V) {
+		Self::insert_helper(&mut self.root, key.split('.'), value)
+	}
+	
+	pub fn root(&mut self) -> &Node<V> {
+		&self.root
+	}
+	
+	// Avoid pissing off the borrow checker
+	fn insert_helper<'a, I>(node: &mut Node<V>, mut current: I, value: V) where I: Iterator<Item=&'a str> {
+		if let Some(part) =  current.next() {
+			if let Some(deeper) = node.deeper_mut(part) {
+				Self::insert_helper(deeper, current, value);
+				return;
+			}
+			
+			node.insert(part, Node::dummy());
+			Self::insert_helper(node.deeper_mut(part).unwrap(), current, value)
+		} else {
+			node.set_leaf(value)
+		}
+	}
+}
+
+#[derive(Debug)]
+pub struct Node<V> {
+	branch: Option<HashMap<String, Node<V>>>,
+	leaf: Option<V>
+}
+
+impl<V> Node<V> {
+	fn dummy() -> Self {
+		Node { branch: None, leaf: None }
+	}
+	
+	fn leaf(value: V) -> Self {
+		Node { branch: None, leaf: Some(value) }
+	}
+	
+	fn branch(map: HashMap<String, Node<V>>) -> Self {
+		Node { branch: Some(map), leaf: None}
+	}
+	
+	fn set_leaf(&mut self, value: V) {
+		// TODO: Use entry APIs when they are stabilized.
+		if let Some(ref mut current) = self.leaf {
+			*current = value
+		} else {
+			self.leaf = Some(value)
+		}
+	}
+	
+	fn insert(&mut self, key: &str, node: Node<V>) {
+		// TODO: Use entry APIs when they are stabilized.
+		if let Some(ref mut br) = self.branch {
+			br.insert(key.to_owned(), node);
+		} else {
+			let mut map = HashMap::new();
+			map.insert(key.to_owned(), node);
+			self.branch = Some(map);
+		}
+	}
+	
+	pub fn deeper(&self, key: &str) -> Option<&Node<V>> {
+		if let Some(ref map) = self.branch {
+			map.get(key)
+		} else {
+			None
+		}
+	}
+	
+	fn deeper_mut(&mut self, key: &str) -> Option<&mut Node<V>> {
+		if let Some(ref mut map) = self.branch {
+			map.get_mut(key)
+		} else {
+			None
+		}
+	}
+	
+	pub fn get(&self) -> Option<&V> {
+		self.leaf.as_ref()
+	}
+	
+	fn get_mut(&mut self) -> Option<&mut V> {
+		self.leaf.as_mut()
+	}
+	
+	pub fn iter(&self) -> Option<Iter<String, Node<V>>> {
+		if let Some(ref br) = self.branch {
+			Some(br.iter())
+		} else {
+			None
+		}
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use glutin::Event;
 use std::io::BufReader;
 use ui::{Scene, State, Element, Kind, Coloring};
 use ui::lit::Lit;
-mod resource;
+//mod resource;
 
 #[macro_use]
 extern crate gfx;

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,10 +322,9 @@ fn main() {
 		let line = line.unwrap();
 		match language::parse_line(&line) {
 			Ok((key, raw)) => {
-				if let Some(compiled) = Compiled::compile(raw) {
-					dir.insert(key, compiled)
-				} else {
-					println!("Compile error: ({}, {})", key, raw)
+				match Compiled::compile(raw) {
+					Ok(compiled) => dir.insert(key, compiled),
+					Err(err) => println!("Compile error: ({}, {}): {:?}", key, raw, err)
 				}
 			},
 			Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod directory;
 
 use render2d::Rect;
 
+use text::language;
 use text::render::Command;
 use std::fs::File;
 use input::Screen;
@@ -313,28 +314,11 @@ fn main() {
 	
 	println!("{}", serde_json::to_string(&scene).unwrap());*/
 	
-	use text::language::{self, Directory, Compiled};
-	
-	let mut dir = Directory::new();
-	let lang_file = BufReader::new(File::open("assets/minecraft/lang/en_US.lang").unwrap());
-	
-	for line in lang_file.lines() {
-		let line = line.unwrap();
-		match language::parse_line(&line) {
-			Ok((key, raw)) => {
-				match Compiled::compile(raw) {
-					Ok(compiled) => dir.insert(key, compiled),
-					Err(err) => println!("Compile error: ({}, {}): {:?}", key, raw, err)
-				}
-			},
-			Err(e) => {
-				if !line.is_empty() {
-					println!("Parse error: {}", line)
-				}
-			}
-		}
-		
-		
+	let name = "assets/minecraft/lang/en_US.lang";
+	let read = BufReader::new(File::open(name).unwrap());
+	let (mut dir, errors) = language::load(read, name).unwrap();
+	for error in &errors {
+		println!("{}", error);
 	}
 	
 	print_helper(None, dir.root(), -1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,7 @@ fn main() {
 		println!("{:?}", component);
 	}*/
 	
-	let mut scene = Scene::new();
+	/*let mut scene = Scene::new();
 	let state = State {
 		name: "default".to_owned(),
 		center: (Lit::new(0.0, 0), Lit::new(0.0, 0)),
@@ -309,5 +309,7 @@ fn main() {
 	
 	scene.elements.insert("test".to_owned(), element);
 	
-	println!("{}", serde_json::to_string(&scene).unwrap());
+	println!("{}", serde_json::to_string(&scene).unwrap());*/
+	
+	
 }

--- a/src/text/flat.rs
+++ b/src/text/flat.rs
@@ -150,7 +150,7 @@ impl ChatBuf {
 	}
 }
 
-struct Components<'a> {
+pub struct Components<'a> {
 	head: &'a str,
 	descriptors: Iter<'a, Descriptor>,
 	level: Level

--- a/src/text/formatter/mod.rs
+++ b/src/text/formatter/mod.rs
@@ -1,0 +1,277 @@
+use std::str::FromStr;
+use std::num::ParseIntError;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Kind {
+	Bool,
+	HexHashCode,
+	String,
+	Unicode,
+	Decimal,
+	Octal,
+	Hex,
+	SciNot,
+	Float,
+	CompSciNot,
+	Hexfloat,
+	Date,
+	Percent,
+	Newline
+}
+
+impl Kind {
+	fn from_character(character: char) -> Option<(Self, bool)> {
+		Some(match character {
+			'b' => (Kind::Bool, 		false),
+			'B' => (Kind::Bool, 		true),
+			'h' => (Kind::HexHashCode, 	false),
+			'H' => (Kind::HexHashCode, 	true),
+			's' => (Kind::String, 		false),
+			'S' => (Kind::String, 		true),
+			'c' => (Kind::Unicode, 		false),
+			'C' => (Kind::Unicode, 		true),
+			'd' => (Kind::Decimal, 		false),
+			'o' => (Kind::Octal, 		false),
+			'x' => (Kind::Hex, 			false),
+			'X' => (Kind::Hex, 			true),
+			'e' => (Kind::SciNot, 		false),
+			'E' => (Kind::SciNot, 		true),
+			'f' => (Kind::Float, 		false),
+			'g' => (Kind::CompSciNot, 	false),
+			'G' => (Kind::CompSciNot, 	true),
+			'a' => (Kind::Hexfloat, 	false),
+			'A' => (Kind::Hexfloat, 	true),
+			't' => (Kind::Date, 		false),
+			'T' => (Kind::Date, 		true),
+			'%' => (Kind::Percent, 		false),
+			'n' => (Kind::Newline, 		false),
+			_ => return None
+		})
+	}
+	
+	fn character(&self, upper: bool) -> char {
+		match *self {
+			Kind::Bool 			=> if upper {'B'} else {'b'},
+			Kind::HexHashCode 	=> if upper {'H'} else {'h'},
+			Kind::String 		=> if upper {'S'} else {'s'},
+			Kind::Unicode 		=> if upper {'C'} else {'c'},
+			Kind::Decimal 		=> 'd',
+			Kind::Octal 		=> 'o',
+			Kind::Hex 			=> if upper {'X'} else {'x'},
+			Kind::SciNot 		=> if upper {'E'} else {'e'},
+			Kind::Float 		=> 'f',
+			Kind::CompSciNot 	=> if upper {'G'} else {'g'},
+			Kind::Hexfloat 		=> if upper {'A'} else {'a'},
+			Kind::Date 			=> if upper {'T'} else {'t'},
+			Kind::Percent 		=> '%',
+			Kind::Newline 		=> 'n'
+		}
+	}
+	
+	fn honors_uppercase(&self) -> bool {
+		match *self {
+			Kind::Bool 			=> true,
+			Kind::HexHashCode 	=> true,
+			Kind::String 		=> true,
+			Kind::Unicode 		=> true,
+			Kind::Decimal 		=> false,
+			Kind::Octal 		=> false,
+			Kind::Hex 			=> true,
+			Kind::SciNot 		=> true,
+			Kind::Float 		=> false,
+			Kind::CompSciNot 	=> true,
+			Kind::Hexfloat 		=> true,
+			Kind::Date 			=> true,
+			Kind::Percent 		=> false,
+			Kind::Newline 		=> false
+		}
+	}
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Flag {
+	LeftJustify,
+	Alternate,
+	Plus,
+	LeadingSpace,
+	ZeroPad,
+	Group,
+	Parentheses,
+	PreviousIndex
+}
+
+impl Flag {
+	fn from_character(character: char) -> Option<Self> {
+		Some(match character {
+			'-' => Flag::LeftJustify,
+			'#' => Flag::Alternate,
+			'+' => Flag::Plus,
+			' ' => Flag::LeadingSpace,
+			'0' => Flag::ZeroPad,
+			',' => Flag::Group,
+			'(' => Flag::Parentheses,
+			'<' => Flag::PreviousIndex,
+			_ => return None
+		})
+	}
+	
+	fn character(&self) -> char {
+		match *self {
+			Flag::LeftJustify 	=> '-',
+			Flag::Alternate 	=> '#',
+			Flag::Plus 			=> '+',
+			Flag::LeadingSpace 	=> ' ',
+			Flag::ZeroPad 		=> '0',
+			Flag::Group 		=> ',',
+			Flag::Parentheses 	=> '(',
+			Flag::PreviousIndex => '<'
+		}
+	}
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Index {
+	Next,
+	Exact(usize),
+	Previous
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+struct Flags(u8);
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct FormatCommand {
+	index: Index,
+	flags: Flags,
+	width: Option<usize>,
+	precision: Option<usize>,
+	kind: Kind,
+	upper: bool
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum ParseFormatError {
+	NotFormat,
+	ParseInt(ParseIntError),
+	ExpectedPrecision,
+	BadConversion
+}
+
+impl FormatCommand {
+	fn parse(s: &str) -> Result<(usize, Self), ParseFormatError> {
+		let start_len = s.len();
+		
+		if !s.starts_with('%') {
+			return Err(ParseFormatError::NotFormat)
+		}
+		
+		let s = &s[1..];
+		let (num, s) = get_num(s);
+		let was_index = s.starts_with('$');
+		
+		let value = if !num.is_empty() {
+			Some(try!(num.parse::<usize>().map_err(ParseFormatError::ParseInt)))
+		} else {
+			None
+		};
+		
+		let s = &s[if was_index {1} else {0}..];
+		
+		let (s, flags, width, arg_idx) = if was_index || num.is_empty() {
+			let mut num_flags = 0;
+			
+			let mut use_prev = false;
+			let mut flags = Flags(0);
+			let mut iter = s.chars().map(Flag::from_character);
+			while let Some(Some(flag)) = iter.next() {
+				if flag == Flag::PreviousIndex {
+					use_prev = true;
+				} else {
+					// TODO: Handle flag
+					unimplemented!();
+				}
+				
+				num_flags += 1;
+			}
+			
+			let (num, s) = get_num(s);
+		
+			let width = if !num.is_empty() {
+				Some(try!(num.parse::<usize>().map_err(ParseFormatError::ParseInt)))
+			} else {
+				None
+			};
+			
+			let index = if use_prev {
+				Index::Previous
+			} else {
+				if let Some(value) = value {
+					if value != 0 {
+						Index::Exact(value)
+					} else {
+						Index::Next
+					}
+				} else {
+					Index::Next
+				}
+			};
+			
+			(s, flags, width, index)
+		} else {
+			(s, Flags(0), value, Index::Next)
+		};
+		
+		let has_precision =  s.starts_with('.');
+		let s = &s[if has_precision {1} else {0}..];
+		
+		let (s, precision) = if has_precision {
+			let (num, s) = get_num(s);
+		
+			(s, if !num.is_empty() {
+				Some(try!(num.parse::<usize>().map_err(ParseFormatError::ParseInt)))
+			} else {
+				return Err(ParseFormatError::ExpectedPrecision)
+			})
+		} else {
+			(s, None)
+		};
+		
+		let (kind, upper) = if let Some(v) = s.chars().nth(0).and_then(Kind::from_character) {
+			v
+		} else {
+			return Err(ParseFormatError::BadConversion)
+		};
+		
+		Ok((start_len - s.len(), FormatCommand {
+			index: arg_idx,
+			flags: flags,
+			width: width,
+			precision: precision,
+			kind: kind,
+			upper: upper
+		}))
+	}
+}
+
+fn get_num(s: &str) -> (&str, &str) {
+	let mut digits = 0;
+	
+	for c in s.chars() {
+		match c {
+			'0'...'9' => digits += 1,
+			_ => break
+		}
+	}
+	
+	s.split_at(digits)
+}
+
+#[test]
+fn test_parse() {
+	assert_eq!(Ok(FormatCommand { index: Index::Next, flags: Flags(0), width: None, precision: None, kind: Kind::Decimal, upper: false}), 		   FormatCommand::parse("%d"));
+	assert_eq!(Ok(FormatCommand { index: Index::Exact(42), flags: Flags(0), width: None, precision: None, kind: Kind::Decimal, upper: false}),     FormatCommand::parse("%42$d"));
+	assert_eq!(Ok(FormatCommand { index: Index::Next, flags: Flags(0), width: Some(43), precision: None, kind: Kind::Decimal, upper: false}),      FormatCommand::parse("%43d"));
+	assert_eq!(Ok(FormatCommand { index: Index::Exact(42), flags: Flags(0), width: Some(43), precision: None, kind: Kind::Decimal, upper: false}), FormatCommand::parse("%42$43d"));
+	assert_eq!(Ok(FormatCommand { index: Index::Next, flags: Flags(0), width: Some(42), precision: Some(43), kind: Kind::Float, upper: false}),    FormatCommand::parse("%42.43f"));
+	assert_eq!(Ok(FormatCommand { index: Index::Exact(41), flags: Flags(0), width: Some(42), precision: Some(43), kind: Kind::Float, upper: false}),FormatCommand::parse("%41$42.43f"));
+}

--- a/src/text/formatter/mod.rs
+++ b/src/text/formatter/mod.rs
@@ -159,14 +159,21 @@ impl TimeKind {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Flag {
+	/// All: Left justify the result. Width must be provided.
 	LeftJustify,
+	/// TODO: TODO
 	Alternate,
+	/// [Decimal, all FP]: Indicates that if the number is non-negative and finite, a '+' should be prepended.
 	Plus,
+	/// [Decimal, all FP]: Indicates that if the number is non-negative, a ' ' should be prepended.
 	LeadingSpace,
+	/// Numeric: Indicates to pad the output with zeroes. Width must be provided. Mutually exclusive with LeftJustify.
 	ZeroPad,
-	/// Indicates to use a locale-specific grouping seperator. (',' in en_US to format the number 10000 as 10,000)
+	/// [Decimal, SciNot, Float, CompSciNot]: Indicates to use a locale-specific grouping seperator. (',' in en_US to format the number 10000 as 10,000)
 	Group,
+	/// [Decimal, SciNot, Float, CompSciNot]: Indicates to surround the value with '(' and ')' if it is negative.
 	Parentheses,
+	/// Meta: Indicator to argument index picker to use the last index. Meta-flag.
 	PreviousIndex
 }
 

--- a/src/text/formatter/mod.rs
+++ b/src/text/formatter/mod.rs
@@ -14,13 +14,13 @@ enum Kind {
 	Float,
 	CompSciNot,
 	Hexfloat,
-	Date,
+	Time(TimeKind),
 	Percent,
 	Newline
 }
 
 impl Kind {
-	fn from_character(character: char) -> Option<(Self, bool)> {
+	fn from_character(character: char, other: Option<char>) -> Option<(Self, bool)> {
 		Some(match character {
 			'b' => (Kind::Bool, 		false),
 			'B' => (Kind::Bool, 		true),
@@ -41,8 +41,8 @@ impl Kind {
 			'G' => (Kind::CompSciNot, 	true),
 			'a' => (Kind::Hexfloat, 	false),
 			'A' => (Kind::Hexfloat, 	true),
-			't' => (Kind::Date, 		false),
-			'T' => (Kind::Date, 		true),
+			't' => return other.and_then(TimeKind::from_character).map(|tk| (Kind::Time(tk), false)),
+			'T' => return other.and_then(TimeKind::from_character).map(|tk| (Kind::Time(tk), true)),
 			'%' => (Kind::Percent, 		false),
 			'n' => (Kind::Newline, 		false),
 			_ => return None
@@ -62,9 +62,16 @@ impl Kind {
 			Kind::Float 		=> 'f',
 			Kind::CompSciNot 	=> if upper {'G'} else {'g'},
 			Kind::Hexfloat 		=> if upper {'A'} else {'a'},
-			Kind::Date 			=> if upper {'T'} else {'t'},
+			Kind::Time(_) 		=> if upper {'T'} else {'t'},
 			Kind::Percent 		=> '%',
 			Kind::Newline 		=> 'n'
+		}
+	}
+	
+	fn second_character(&self) -> Option<char> {
+		match *self {
+			Kind::Time(tk) => Some(tk.character()),
+			_ => None
 		}
 	}
 	
@@ -81,9 +88,71 @@ impl Kind {
 			Kind::Float 		=> false,
 			Kind::CompSciNot 	=> true,
 			Kind::Hexfloat 		=> true,
-			Kind::Date 			=> true,
+			Kind::Time(_) 		=> true,
 			Kind::Percent 		=> false,
 			Kind::Newline 		=> false
+		}
+	}
+}
+
+/// Unless otherwise specified, each of these is padded
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum TimeKind {
+	/// Hour of the 24 hour clock. Padded with zeros if neccesary (00 - 23)
+	Hour24,
+	/// Hour of the 12 hour clock. Padded with zeros if neccesary (01 - 12)
+	Hour12,
+	/// Hour of the 24 hour clock (0 - 23).
+	UnpaddedHour24,
+	/// Hour of the 12 hour clock (0 - 12).
+	UnpaddedHour12,
+	Minute,
+	Second,
+	Milli,
+	Nano,
+	/// Marker for morning or afternoon, such as AM/PM.
+	Marker,
+	TzOffset,
+	TzAbbrev,
+	EpochSecond,
+	EpochMilli
+}
+
+impl TimeKind {
+	fn from_character(character: char) -> Option<Self> {
+		Some(match character {
+			'H' => TimeKind::Hour24,
+			'I' => TimeKind::Hour12,
+			'k' => TimeKind::UnpaddedHour24,
+			'l' => TimeKind::UnpaddedHour12,
+			'M' => TimeKind::Minute,
+			'S' => TimeKind::Second,
+			'L' => TimeKind::Milli,
+			'N' => TimeKind::Nano,
+			'p' => TimeKind::Marker,
+			'z' => TimeKind::TzOffset,
+			'Z' => TimeKind::TzAbbrev,
+			's' => TimeKind::EpochSecond,
+			'Q' => TimeKind::EpochMilli,
+			_ => return None
+		})
+	}
+	
+	fn character(&self) -> char {
+		match *self {
+			TimeKind::Hour24 => 'H',
+			TimeKind::Hour12 => 'I',
+			TimeKind::UnpaddedHour24 => 'k',
+			TimeKind::UnpaddedHour12 => 'l',
+			TimeKind::Minute => 'M',
+			TimeKind::Second => 'S',
+			TimeKind::Milli => 'L',
+			TimeKind::Nano => 'N',
+			TimeKind::Marker => 'p',
+			TimeKind::TzOffset => 'z',
+			TimeKind::TzAbbrev => 'Z',
+			TimeKind::EpochSecond => 's',
+			TimeKind::EpochMilli => 'Q',
 		}
 	}
 }
@@ -95,6 +164,7 @@ enum Flag {
 	Plus,
 	LeadingSpace,
 	ZeroPad,
+	/// Indicates to use a locale-specific grouping seperator. (',' in en_US to format the number 10000 as 10,000)
 	Group,
 	Parentheses,
 	PreviousIndex
@@ -127,6 +197,19 @@ impl Flag {
 			Flag::PreviousIndex => '<'
 		}
 	}
+	
+	fn bit(&self) -> u8 {
+		match *self {
+			Flag::LeftJustify 	=> 1,
+			Flag::Alternate 	=> 2,
+			Flag::Plus 			=> 4,
+			Flag::LeadingSpace 	=> 8,
+			Flag::ZeroPad 		=> 16,
+			Flag::Group 		=> 32,
+			Flag::Parentheses 	=> 64,
+			Flag::PreviousIndex => 0
+		}
+	}
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -138,6 +221,44 @@ enum Index {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 struct Flags(u8);
+
+impl Flags {
+	fn handle(&mut self, flag: Flag)  {
+		self.0 |= flag.bit()
+	}
+	
+	pub fn any(&self) -> bool {
+		self.0 != 0
+	}
+	
+	pub fn left_justify(&self) -> bool {
+		self.0 & Flag::LeftJustify.bit() != 0
+	}
+	
+	pub fn alternate(&self) -> bool {
+		self.0 & Flag::Alternate.bit() != 0
+	}
+	
+	pub fn plus(&self) -> bool {
+		self.0 & Flag::Plus.bit() != 0
+	}
+	
+	pub fn leasing_space(&self) -> bool {
+		self.0 & Flag::LeadingSpace.bit() != 0
+	}
+	
+	pub fn zero_pad(&self) -> bool {
+		self.0 & Flag::ZeroPad.bit() != 0
+	}
+	
+	pub fn group(&self) -> bool {
+		self.0 & Flag::Group.bit() != 0
+	}
+	
+	pub fn parentheses(&self) -> bool {
+		self.0 & Flag::Parentheses.bit() != 0
+	}
+}
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct FormatCommand {
@@ -158,43 +279,55 @@ enum ParseFormatError {
 }
 
 impl FormatCommand {
+	/// Parses a format command of the form %[argument_index$][flags][width][.precision]conversion[date_conversion] into an object.
+	/// Returns the amount of bytes consumed from the buffer along with the parsed format command.
 	fn parse(s: &str) -> Result<(usize, Self), ParseFormatError> {
+		// Record the starting length of the string, so that the length of the format code can be found later.
 		let start_len = s.len();
 		
+		// All format codes start with a %
 		if !s.starts_with('%') {
 			return Err(ParseFormatError::NotFormat)
 		}
 		
-		let s = &s[1..];
-		let (num, s) = get_num(s);
+		// Get the first number, which may either be the argument index or the width. If there is not number here, then it was either flags, start of precision, or the conversion.
+		let (num, s) = get_num(&s[1..]);
 		let was_index = s.starts_with('$');
 		
+		// Try to parse the numeric value.
 		let value = if !num.is_empty() {
 			Some(try!(num.parse::<usize>().map_err(ParseFormatError::ParseInt)))
 		} else {
 			None
 		};
 		
-		let s = &s[if was_index {1} else {0}..];
+		let mut flags = Flags(0);
 		
-		let (s, flags, width, arg_idx) = if was_index || num.is_empty() {
+		let (s, width, arg_idx) = if was_index || num.is_empty() {
+			// Remove the '$' character, if present.
+			let s = &s[if was_index {1} else {0}..];
 			let mut num_flags = 0;
-			
 			let mut use_prev = false;
-			let mut flags = Flags(0);
+			
 			let mut iter = s.chars().map(Flag::from_character);
 			while let Some(Some(flag)) = iter.next() {
-				if flag == Flag::PreviousIndex {
-					use_prev = true;
-				} else {
-					// TODO: Handle flag
-					unimplemented!();
+				match flag {
+					Flag::PreviousIndex => use_prev = true,
+					flag => flags.handle(flag)
 				}
 				
 				num_flags += 1;
 			}
 			
-			let (num, s) = get_num(s);
+			let index = match (use_prev, value) {
+				(true, _)        => Index::Previous,
+				(false, None)    => Index::Next,
+				(false, Some(0)) => Index::Next,
+				(false, Some(x)) => Index::Exact(x)
+			};
+			
+			// While num_flags is a character count and not a byte count, this is still valid as all flags are single-byte characters.
+			let (num, s) = get_num(&s[num_flags..]);
 		
 			let width = if !num.is_empty() {
 				Some(try!(num.parse::<usize>().map_err(ParseFormatError::ParseInt)))
@@ -202,30 +335,13 @@ impl FormatCommand {
 				None
 			};
 			
-			let index = if use_prev {
-				Index::Previous
-			} else {
-				if let Some(value) = value {
-					if value != 0 {
-						Index::Exact(value)
-					} else {
-						Index::Next
-					}
-				} else {
-					Index::Next
-				}
-			};
-			
-			(s, flags, width, index)
+			(s, width, index)
 		} else {
-			(s, Flags(0), value, Index::Next)
+			(s, value, Index::Next)
 		};
 		
-		let has_precision =  s.starts_with('.');
-		let s = &s[if has_precision {1} else {0}..];
-		
-		let (s, precision) = if has_precision {
-			let (num, s) = get_num(s);
+		let (s, precision) = if s.starts_with('.') {
+			let (num, s) = get_num(&s[1..]);
 		
 			(s, if !num.is_empty() {
 				Some(try!(num.parse::<usize>().map_err(ParseFormatError::ParseInt)))
@@ -236,13 +352,15 @@ impl FormatCommand {
 			(s, None)
 		};
 		
-		let (kind, upper) = if let Some(v) = s.chars().nth(0).and_then(Kind::from_character) {
-			v
-		} else {
-			return Err(ParseFormatError::BadConversion)
+		let (kind, upper) = try! {
+			s.chars().nth(0)
+			.and_then(|first| 
+				Kind::from_character(first, s.chars().nth(1))
+			)
+			.ok_or(ParseFormatError::BadConversion)
 		};
 		
-		Ok((start_len - s.len(), FormatCommand {
+		Ok((start_len - s.len() + 1, FormatCommand {
 			index: arg_idx,
 			flags: flags,
 			width: width,
@@ -268,10 +386,10 @@ fn get_num(s: &str) -> (&str, &str) {
 
 #[test]
 fn test_parse() {
-	assert_eq!(Ok(FormatCommand { index: Index::Next, flags: Flags(0), width: None, precision: None, kind: Kind::Decimal, upper: false}), 		   FormatCommand::parse("%d"));
-	assert_eq!(Ok(FormatCommand { index: Index::Exact(42), flags: Flags(0), width: None, precision: None, kind: Kind::Decimal, upper: false}),     FormatCommand::parse("%42$d"));
-	assert_eq!(Ok(FormatCommand { index: Index::Next, flags: Flags(0), width: Some(43), precision: None, kind: Kind::Decimal, upper: false}),      FormatCommand::parse("%43d"));
-	assert_eq!(Ok(FormatCommand { index: Index::Exact(42), flags: Flags(0), width: Some(43), precision: None, kind: Kind::Decimal, upper: false}), FormatCommand::parse("%42$43d"));
-	assert_eq!(Ok(FormatCommand { index: Index::Next, flags: Flags(0), width: Some(42), precision: Some(43), kind: Kind::Float, upper: false}),    FormatCommand::parse("%42.43f"));
-	assert_eq!(Ok(FormatCommand { index: Index::Exact(41), flags: Flags(0), width: Some(42), precision: Some(43), kind: Kind::Float, upper: false}),FormatCommand::parse("%41$42.43f"));
+	assert_eq!(Ok((2, FormatCommand { index: Index::Next, flags: Flags(0), width: None, precision: None, kind: Kind::Decimal, upper: false})), 		   FormatCommand::parse("%d"));
+	assert_eq!(Ok((5, FormatCommand { index: Index::Exact(42), flags: Flags(0), width: None, precision: None, kind: Kind::Decimal, upper: false})),     FormatCommand::parse("%42$d"));
+	assert_eq!(Ok((4, FormatCommand { index: Index::Next, flags: Flags(0), width: Some(43), precision: None, kind: Kind::Decimal, upper: false})),      FormatCommand::parse("%43d"));
+	assert_eq!(Ok((7, FormatCommand { index: Index::Exact(42), flags: Flags(0), width: Some(43), precision: None, kind: Kind::Decimal, upper: false})), FormatCommand::parse("%42$43d"));
+	assert_eq!(Ok((7, FormatCommand { index: Index::Next, flags: Flags(0), width: Some(42), precision: Some(43), kind: Kind::Float, upper: false})),    FormatCommand::parse("%42.43f"));
+	assert_eq!(Ok((10, FormatCommand { index: Index::Exact(41), flags: Flags(0), width: Some(42), precision: Some(43), kind: Kind::Float, upper: false})),FormatCommand::parse("%41$42.43f"));
 }

--- a/src/text/formatter/mod.rs
+++ b/src/text/formatter/mod.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::num::ParseIntError;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-enum Kind {
+pub enum Kind {
 	Bool,
 	HexHashCode,
 	String,
@@ -97,7 +97,7 @@ impl Kind {
 
 /// Unless otherwise specified, each of these is padded
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-enum TimeKind {
+pub enum TimeKind {
 	/// Hour of the 24 hour clock. Padded with zeros if neccesary (00 - 23)
 	Hour24,
 	/// Hour of the 12 hour clock. Padded with zeros if neccesary (01 - 12)
@@ -158,7 +158,7 @@ impl TimeKind {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-enum Flag {
+pub enum Flag {
 	LeftJustify,
 	Alternate,
 	Plus,
@@ -213,17 +213,17 @@ impl Flag {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-enum Index {
+pub enum Index {
 	Next,
 	Exact(usize),
 	Previous
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-struct Flags(u8);
+pub struct Flags(u8);
 
 impl Flags {
-	fn handle(&mut self, flag: Flag)  {
+	pub fn handle(&mut self, flag: Flag)  {
 		self.0 |= flag.bit()
 	}
 	
@@ -261,17 +261,17 @@ impl Flags {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-struct FormatCommand {
-	index: Index,
-	flags: Flags,
-	width: Option<usize>,
-	precision: Option<usize>,
-	kind: Kind,
-	upper: bool
+pub struct FormatCommand {
+	pub index: Index,
+	pub flags: Flags,
+	pub width: Option<usize>,
+	pub precision: Option<usize>,
+	pub kind: Kind,
+	pub upper: bool
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-enum ParseFormatError {
+pub enum ParseFormatError {
 	NotFormat,
 	ParseInt(ParseIntError),
 	ExpectedPrecision,
@@ -281,7 +281,7 @@ enum ParseFormatError {
 impl FormatCommand {
 	/// Parses a format command of the form %[argument_index$][flags][width][.precision]conversion[date_conversion] into an object.
 	/// Returns the amount of bytes consumed from the buffer along with the parsed format command.
-	fn parse(s: &str) -> Result<(usize, Self), ParseFormatError> {
+	pub fn parse(s: &str) -> Result<(usize, Self), ParseFormatError> {
 		// Record the starting length of the string, so that the length of the format code can be found later.
 		let start_len = s.len();
 		

--- a/src/text/formatter/transform.rs
+++ b/src/text/formatter/transform.rs
@@ -1,0 +1,148 @@
+use text::formatter::{FormatCommand, Kind, Flag};
+
+#[derive(Debug, Clone, PartialEq)]
+enum Prim {
+	Bool(bool),
+	Null,
+	Undefined,
+	Integer(i64),
+	Float(f64),
+	String(String)
+}
+
+enum PaddingStrategy {
+	/// [  -123]
+	RightAlign,
+	/// [-123  ]
+	LeftAlign,
+	/// [-00123]
+	ZeroPad
+}
+
+enum Sign {
+	/// For negative numbers: "-num". For positive numbers: "num"
+	Minus,
+	/// For negative numbers: "(num)". For positive numbers: "num"
+	Surround,
+	/// For negative numbers: "-num". For positive numbers: "+num"
+	PositivePlus,
+	/// For negative numbers: "-num". For positive numbers: " num"
+	PositiveSpace
+}
+
+struct NumericRep {
+	sign: Sign,
+	group: bool
+}
+
+struct Target {
+	min_width: usize,
+	precision: Option<usize>,
+	strategy: PaddingStrategy,
+	repr: NumericRep,
+	trans: Trans
+}
+
+enum Error {
+	ConflictingFlags(Flag, Flag),
+	UnsupportedKind(Kind),
+	NoAlternate,
+	Escape
+}
+
+impl Target {
+	fn from_unchecked(cmd: &FormatCommand) -> Result<Self, Error> {
+		// TODO: Alternate
+		
+		Ok(Target {
+			min_width: cmd.width.unwrap_or(0),
+			precision: cmd.precision,
+			strategy: match (cmd.flags.zero_pad(), cmd.flags.left_justify()) {
+				(true, false) => PaddingStrategy::ZeroPad,
+				(false, true) => PaddingStrategy::LeftAlign,
+				(false, false) => PaddingStrategy::RightAlign,
+				(true, true) => return Err(Error::ConflictingFlags(Flag::ZeroPad, Flag::LeftJustify))
+			},
+			repr: NumericRep { 
+				sign: {
+					if cmd.flags.parentheses() {
+						Sign::Surround
+					} else if cmd.flags.plus() {
+						if cmd.flags.leading_space() {
+							return Err(Error::ConflictingFlags(Flag::Plus, Flag::LeadingSpace))
+						}
+						
+						Sign::PositivePlus
+					} else if cmd.flags.leading_space() {
+						Sign::PositiveSpace
+					} else {
+						Sign::Minus
+					}
+				}, 
+				group: cmd.flags.group() 
+			},
+			trans: match (cmd.kind, cmd.flags.alternate()) {
+				(Kind::Bool, false) => Trans::Bool,
+				(Kind::Bool, true) => return Err(Error::NoAlternate),
+				// TODO: Kind::HexHashCode: NoAlternate
+				// TODO: Kind::String: NoAlternate
+				// TODO: Kind::Character: NoAlternate
+				(Kind::Decimal, false) => Trans::Decimal,
+				(Kind::Decimal, true) => return Err(Error::NoAlternate),
+				(Kind::Octal, flag) => Trans::Octal { has_radix: flag },
+				(Kind::Hex, flag) => Trans::Hex { has_radix: flag },
+				(Kind::SciNot, false) => Trans::SciNot,
+				(Kind::SciNot, true) => return Err(Error::NoAlternate),
+				(Kind::Float, flag) => Trans::Float { force_decimal: flag },
+				(Kind::CompSciNot, flag) => Trans::CompSciNot { force_decimal: flag },
+				(Kind::Hexfloat, flag) => Trans::Hexfloat { force_decimal: flag },
+				// TODO: Time
+				(Kind::Percent, _) => return Err(Error::Escape),
+				(Kind::Newline, _) => return Err(Error::Escape),
+				_ => return Err(Error::UnsupportedKind(cmd.kind))
+			}
+		})
+	}
+	
+	// TODO: precision for Kind::Bool, Kind::HexHashCode, Kind::String is max_chars
+	// TODO: precision for [all FP] is TODO
+	// TODO: precision for Kind::Unciode, Decimal, Octal, Hex is invalid
+	
+	
+	fn from(cmd: &FormatCommand) -> Result<Self, Error> {
+		let target = try!(Self::from_unchecked(cmd));
+		
+		// check kind is Octal, Hex, [all FP] if Alt
+		// check kind is Decimal, [all FP] if Sign::PositivePlus or Sign::PositiveSpace
+		// check kind is [all Numeric] if PaddingStrategy::ZeroPad,
+		// check kind is Decimal, SciNot, Float, CompSciNot if group==true or Sign::Surround
+		// Kind::Octal / Kind::Hex: Reject sign if non Sign::Minus, reject if group==true.
+		// TODO: Floats and Doubles, Time
+		
+		Ok(target)
+	}
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Trans {
+	Bool,
+	// NUMERIC
+	Decimal,
+	Octal { has_radix: bool },
+	Hex { has_radix: bool },
+	// NUMERIC-FP
+	SciNot,
+	Float { force_decimal: bool },
+	CompSciNot { force_decimal: bool },
+	Hexfloat { force_decimal: bool },
+}
+
+fn trans(transform: &Trans, prim: &Prim) -> &'static str {
+	match (transform, prim) {
+		(&Trans::Bool, &Prim::Bool(b)) => if b {"true"} else {"false"},
+		(&Trans::Bool, &Prim::Null) => "false",
+		(&Trans::Bool, &Prim::Undefined) => "false",
+		(&Trans::Bool, _) => "true",
+		_ => panic!()
+	}
+}

--- a/src/text/language.rs
+++ b/src/text/language.rs
@@ -1,4 +1,40 @@
 use text::formatter::{Kind, FormatCommand, Index};
+use std::collections::HashMap;
+
+struct Node {
+	branch: Option<HashMap<String, Node>>,
+	leaf: Option<Compiled>
+}
+
+impl Node {
+	fn leaf(compiled: Compiled) -> Self {
+		Node { branch: None, leaf: Some(compiled) }
+	}
+	
+	fn branch(map: HashMap<String, Node>) -> Self {
+		Node { branch: Some(map), leaf: None}
+	}
+	
+	fn set_leaf(&mut self, compiled: Compiled) {
+		// TODO: Use entry APIs when they are stabilized.
+		if let Some(ref mut current) = self.leaf {
+			*current = compiled
+		} else {
+			self.leaf = Some(compiled)
+		}
+	}
+	
+	fn insert(&mut self, key: &str, node: Node) {
+		// TODO: Use entry APIs when they are stabilized.
+		if let Some(ref mut br) = self.branch {
+			br.insert(key.to_owned(), node);
+		} else {
+			let mut map = HashMap::new();
+			map.insert(key.to_owned(), node);
+			self.branch = Some(map);
+		}
+	}
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum Error {
@@ -112,4 +148,5 @@ fn test_parse_lines() {
 	assert_eq!(Ok((" translation.test.none", "Hello, world! ")), parse_line(" translation.test.none=Hello, world! "));
 	assert_eq!(Err(Error::Comment), parse_line("# This is an interesting comment."));
 	assert_eq!(Err(Error::NoValue), parse_line("I'm a strong, independent key and ain't no value gonna mess with me."));
+	assert_eq!(Err(Error::NoValue), parse_line(""));
 }

--- a/src/text/language.rs
+++ b/src/text/language.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Error {
+	Comment,
+	NoValue
+}
+
+fn parse_line(line: &str) -> Result<(&str, &str), Error> {
+	if line.starts_with("#") {
+		// Comment
+		return Err(Error::Comment);
+	}
+	
+	let mut items = line.split("=");
+	
+	// TODO: Formatting
+	// TODO: Formatting: Any Decimal or Float format code is replaced with a format code equivalent to %1s
+	
+	Ok((
+		items.next().expect("A split iterator should yield at least one element!"), 
+		try!(items.next().ok_or(Error::NoValue))
+	))
+}
+
+// TODO: Format strings
+
+#[test]
+fn test_parse_lines() {
+	assert_eq!(Ok(("translation.test.none", "Hello, world!")), parse_line("translation.test.none=Hello, world!"));
+	assert_eq!(Ok(("translation.test.none", "Hello, world!")), parse_line("translation.test.none=Hello, world!=whatever"));
+	assert_eq!(Ok((" translation.test.none", "Hello, world! ")), parse_line(" translation.test.none=Hello, world! "));
+	assert_eq!(Err(Error::Comment), parse_line("# This is an interesting comment."));
+	assert_eq!(Err(Error::NoValue), parse_line("I'm a strong, independent key and ain't no value gonna mess with me."));
+}

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -5,3 +5,5 @@ pub mod default;
 mod align;
 pub mod render;
 pub mod flat;
+mod language;
+mod formatter;

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -5,5 +5,5 @@ pub mod default;
 mod align;
 pub mod render;
 pub mod flat;
-mod language;
+pub mod language;
 mod formatter;


### PR DESCRIPTION
This supports basic formatting codes. It also represents the language data in a tree structure, which allows for easy modification and viewing while remaining compatible with default. It also reduces the volume of each HashMap, which results in lower collisions. In addition, errors look like those from rustc, and are actually helpful, as opposed to a cryptic stacktrace.

Issues
 - Doesn't support advanced formatting codes
 - Doesn't support creating the formatted string yet